### PR TITLE
feat: add nested writes via CreateSerializer.nested

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@
 | 26 | ~~NinjaAIORouter~~ | `ninja_aio/router.py`, `ninja_aio/api.py` | v2.32.0 | Composable router with `.view()` and `.viewset()` decorators. Attach via `api.add_router()` or `@api.router()`. Enables versioned and domain-separated API layouts. |
 | 27 | ~~Field selection~~ | `ninja_aio/views/mixins.py` | v2.33.0 | `FieldSelectionViewSetMixin` — `?fields=id,name,email` on list and retrieve. Reduces payload. Unknown field names ignored; falls back to full response. |
 | 28 | ~~`@on` detail action shorthand~~ | `ninja_aio/decorators/actions.py`, `ninja_aio/views/api.py` | v2.33.0 | `@on("publish")` pre-fetches the object, runs `on_before_operation` + `on_before_object_operation`, passes `obj` to the handler — zero boilerplate. |
+| 29 | ~~Nested writes~~ | `ninja_aio/models/serializers.py`, `ninja_aio/models/utils.py` | unreleased | `CreateSerializer.nested = {"items": ChildSerializer}` — create parent + reverse-FK children atomically in one request. Child's FK back to parent auto-excluded from the generated nested schema and injected at creation time; each child goes through its own full create pipeline (validators, `custom_actions`, `post_create`, reactive hooks). Create-only by design; runs inside the existing `aatomic()` transaction. M2M relations remain out of scope (already served by `ManyToManyAPI`). |
 
 ---
 
@@ -45,7 +46,6 @@
 |---|------|---------|-------------|
 | 24 | Multi-tenancy mixin | `views/mixins.py` | `TenantViewSetMixin` — auto tenant filtering on all queries from header or JWT claim. |
 | 25 | Aggregation endpoints | `views/mixins.py` | `AggregationViewSetMixin` — COUNT, SUM, AVG, MIN, MAX on list views for dashboards. |
-| 27 | Nested writes | `models/utils.py`, `views/api.py` | Create parent + children in one atomic request. `POST /order` with `{"items": [...]}`. |
 | 28 | File upload mixin | `views/mixins.py` | `FileUploadViewSetMixin` — `POST /{pk}/upload` with `multipart/form-data`, configurable storage (local, S3). |
 | 29 | Auto admin inlines | `admin.py` | Extend `@register_admin` to auto-generate `InlineModelAdmin` for FK/M2M relations. |
 | 30 | Admin actions from ViewSet | `admin.py` | `@action` endpoints become available as Django Admin actions. `@action("publish")` → admin "Publish selected" action. |

--- a/docs/api/models/model_serializer.md
+++ b/docs/api/models/model_serializer.md
@@ -57,6 +57,7 @@ Describes how to build a create (input) schema for a model.
 | `optionals` | `list[tuple[str, type]]` | Optional model fields: `(field_name, python_type)`                                                                                |
 | `customs`   | `list[tuple]`            | Synthetic inputs. Tuple forms: `(name, type)` = required (no default); `(name, type, default)` = optional (literal or callable)   |
 | `excludes`  | `list[str]`              | Field names rejected on create                                                                                                    |
+| `nested`    | `dict[str, type[ModelSerializer]]` | Reverse-FK child relations created atomically with the parent. See [Nested Writes](#nested-writes) below.                |
 
 **Example:**
 
@@ -114,6 +115,94 @@ class UserIn(ModelSchema):
         model = User
         fields = ["username", "email"]
 ```
+
+### Nested Writes
+
+`CreateSerializer.nested` lets a parent create endpoint accept and persist its
+reverse-FK children in the same request, atomically. This is distinct from
+M2M relations (`ManyToManyAPI`, see [Views: Mixins](../views/mixins.md)),
+which link *existing* objects — nested writes *create new owned children*
+that don't exist yet.
+
+```python
+class OrderItem(ModelSerializer):
+    order = models.ForeignKey(
+        "Order", on_delete=models.CASCADE, related_name="items"
+    )
+    product = models.ForeignKey(Product, on_delete=models.PROTECT)
+    quantity = models.PositiveIntegerField(default=1)
+
+    class CreateSerializer:
+        # "order" is intentionally omitted: it is injected by the parent
+        # and must never be supplied by the client.
+        fields = ["product", "quantity"]
+
+
+class Order(ModelSerializer):
+    customer = models.ForeignKey(Customer, on_delete=models.PROTECT)
+
+    class ReadSerializer:
+        fields = ["id", "customer", "items"]
+
+    class CreateSerializer:
+        fields = ["customer"]
+        nested = {"items": OrderItem}
+```
+
+A single request now creates the order and all of its items in one atomic
+transaction:
+
+```http
+POST /orders/
+Content-Type: application/json
+
+{
+  "customer": 5,
+  "items": [
+    {"product": 1, "quantity": 2},
+    {"product": 3, "quantity": 1}
+  ]
+}
+```
+
+```json
+{
+  "id": 42,
+  "customer": 5,
+  "items": [
+    {"id": 101, "order": 42, "product": 1, "quantity": 2},
+    {"id": 102, "order": 42, "product": 3, "quantity": 1}
+  ]
+}
+```
+
+**Key `dict` is the reverse accessor / `related_name`** on the parent model
+(`"items"` above matches `related_name="items"` on `OrderItem.order`). The
+value is the child's `ModelSerializer` class.
+
+**Rules:**
+
+- The child's FK back to the parent (`order` above) must **not** appear in
+  the child's `CreateSerializer.fields` — it is resolved automatically via
+  `related_name` and injected before the child is created. If omitted, the
+  framework also excludes it defensively even without an explicit `fields`
+  list.
+- Each child payload is validated against the *child's own* create schema
+  (minus the injected FK), so the child's own custom fields, optionals,
+  validators, `custom_actions`, `post_create`, and reactive hooks (`@on_create`,
+  etc.) all run normally for every nested item.
+- Creation runs inside the same `aatomic()` transaction as the parent — if
+  any child fails validation or persistence, the parent create is rolled
+  back too.
+- Omitting the nested key from the payload defaults to an empty list (no
+  children created); it is never required.
+- **Create-only.** There is no update/patch equivalent — updating a
+  collection of children (replace vs. merge vs. diff-by-pk) has ambiguous
+  semantics, so it's intentionally out of scope. Manage children via their
+  own CRUD endpoints after creation.
+- Only reverse-FK relations are supported. M2M relations should continue to
+  use `ManyToManyAPI` (`m2m_relations` on `APIViewSet`), since linking
+  existing rows is a different operation from creating owned children.
 
 ### ReadSerializer
 
@@ -1149,10 +1238,11 @@ Convert incoming schema to model-ready dict.
 
 **Transformations:**
 
-1. Strips custom fields (stored separately)
-2. Removes optional fields with `None` value
-3. Decodes BinaryField (base64 → bytes)
-4. Resolves FK IDs to model instances
+1. Strips nested-write fields (see `CreateSerializer.nested`), returned separately
+2. Strips custom fields (stored separately)
+3. Removes optional fields with `None` value
+4. Decodes BinaryField (base64 → bytes)
+5. Resolves FK IDs to model instances
 
 ```python
 from ninja import Schema
@@ -1172,7 +1262,7 @@ data = UserCreateSchema(
     send_welcome=True
 )
 
-payload, customs = await util.parse_input_data(request, data)
+payload, customs, nested = await util.parse_input_data(request, data)
 
 # payload = {
 #     "username": "john",
@@ -1181,7 +1271,15 @@ payload, customs = await util.parse_input_data(request, data)
 #     "avatar": b'\x89PNG\r\n...'
 # }
 # customs = {"send_welcome": True}
+# nested = {}  # populated only when CreateSerializer.nested is configured
 ```
+
+!!! note "Return signature"
+    `parse_input_data` returns a 3-tuple: `(payload, customs, nested)`. `nested`
+    is a `dict[str, list[dict]]` mapping each `CreateSerializer.nested` key to
+    its raw child payloads, already popped out of `payload` before FK
+    resolution runs. It is consumed internally by `create_s()` — most callers
+    can ignore it (`payload, customs, _ = await util.parse_input_data(...)`).
 
 #### `parse_output_data(request, data)`
 

--- a/ninja_aio/models/serializers.py
+++ b/ninja_aio/models/serializers.py
@@ -1182,6 +1182,22 @@ class BaseSerializer:
         return cls._apply_validators(schema, validators, model_config, schema_overrides)
 
     @classmethod
+    def get_nested_customs(cls) -> list[tuple[str, Any, Any]]:
+        """
+        Return synthetic custom field tuples for nested-write relations.
+
+        Overridden by ``ModelSerializer`` to translate ``CreateSerializer.nested``
+        into ``(field_name, list[ChildInSchema], default)`` tuples consumable by
+        ``create_schema``. The base implementation is a no-op so ``Serializer``
+        (Meta-driven) does not need to support nested writes.
+
+        Returns
+        -------
+        list[tuple[str, Any, Any]]
+        """
+        return []
+
+    @classmethod
     def _create_in_or_patch_schema(
         cls,
         schema_type: type[SCHEMA_TYPES],
@@ -1197,6 +1213,8 @@ class BaseSerializer:
         customs = (
             cls.get_custom_fields(s_type) + optionals + cls.get_inline_customs(s_type)
         )
+        if schema_type == "In":
+            customs = customs + cls.get_nested_customs()
         excludes = cls.get_excluded_fields(s_type)
 
         # If no explicit fields and no excludes specified
@@ -1467,12 +1485,21 @@ class ModelSerializer(models.Model, BaseSerializer, metaclass=ModelSerializerMet
             Synthetic input fields (non-model).
         excludes : list[str]
             Disallowed model fields on create (e.g., id, timestamps).
+        nested : dict[str, type[ModelSerializer]]
+            Reverse-FK child relations to create atomically with the parent.
+            Key is the reverse accessor / ``related_name`` on the parent model
+            (e.g. ``"items"``); value is the child ``ModelSerializer`` class.
+            The child's own FK back to the parent is auto-excluded from the
+            generated nested input schema and injected at creation time --
+            it must not be listed in the child's ``CreateSerializer.fields``.
+            Only supported for create (not update).
         """
 
         fields: list[str | tuple[str, Any, Any] | tuple[str, Any]] = []
         customs: list[tuple[str, Any, Any] | tuple[str, Any]] = []
         optionals: list[tuple[str, Any]] = []
         excludes: list[str] = []
+        nested: dict[str, type["ModelSerializer"]] = {}
 
     class ReadSerializer:
         """Configuration describing how to build a read (output) schema.
@@ -1629,6 +1656,101 @@ class ModelSerializer(models.Model, BaseSerializer, metaclass=ModelSerializerMet
             Field names whose related objects should be serialized as IDs.
         """
         return getattr(cls.ReadSerializer, "relations_as_id", [])
+
+    @classmethod
+    def get_nested_fields(cls) -> dict[str, type["ModelSerializer"]]:
+        """
+        Return the reverse-FK relations declared for nested creation.
+
+        Reads the ``nested`` attribute from ``CreateSerializer``.
+
+        Returns
+        -------
+        dict[str, type[ModelSerializer]]
+            Mapping of reverse accessor name -> child ``ModelSerializer`` class.
+        """
+        return getattr(cls.CreateSerializer, "nested", {}) or {}
+
+    @classmethod
+    def _get_nested_fk_field(cls, field_name: str) -> str:
+        """
+        Resolve the FK field name on the child model for a nested relation.
+
+        Parameters
+        ----------
+        field_name : str
+            Reverse accessor / ``related_name`` declared in ``nested``.
+
+        Returns
+        -------
+        str
+            Name of the FK field on the child model pointing back to ``cls``.
+        """
+        return cls._meta.get_field(field_name).field.name
+
+    @classmethod
+    def generate_nested_child_schema(cls, fk_field_name: str) -> Schema:
+        """
+        Build the create-input schema used for this model as a nested child.
+
+        Identical to ``generate_create_s()`` except ``fk_field_name`` (the FK
+        pointing back at the nested-write parent) is always excluded, since it
+        is injected programmatically rather than supplied by the client.
+        Used both to type the parent's nested custom field and to re-validate
+        each child payload before creation, so the two stay consistent.
+
+        Parameters
+        ----------
+        fk_field_name : str
+            Name of the FK field on this model pointing back at the parent.
+
+        Returns
+        -------
+        Schema
+        """
+        fields = [f for f in cls.get_fields("create") if f != fk_field_name]
+        excludes = [f for f in cls.get_excluded_fields("create") if f != fk_field_name]
+        if not fields:
+            excludes = list(dict.fromkeys(excludes + [fk_field_name]))
+
+        optionals = cls.get_optional_fields("create")
+        inline_customs = (
+            cls.get_custom_fields("create")
+            + optionals
+            + cls.get_inline_customs("create")
+        )
+
+        return create_schema(
+            model=cls._get_model(),
+            name=f"{cls.__name__}NestedIn",
+            fields=fields or None,
+            custom_fields=inline_customs,
+            exclude=excludes if not fields else None,
+        )
+
+    @classmethod
+    def get_nested_customs(cls) -> list[tuple[str, Any, Any]]:
+        """
+        Build ``(field_name, list[ChildInSchema], default)`` tuples for nested writes.
+
+        For each entry in ``CreateSerializer.nested``, generates a dedicated
+        input schema for the child model that excludes the FK field pointing
+        back at the parent (it is injected at creation time, not supplied by
+        the client).
+
+        Returns
+        -------
+        list[tuple[str, Any, Any]]
+            Custom field tuples consumable by ``create_schema``.
+        """
+        customs = []
+        for field_name, child_serializer in cls.get_nested_fields().items():
+            fk_field_name = cls._get_nested_fk_field(field_name)
+            child_schema = child_serializer.generate_nested_child_schema(fk_field_name)
+            customs.append(
+                (field_name, list[child_schema], Field(default_factory=list))
+            )
+        return customs
 
     @classmethod
     def _get_fields(cls, s_type: type[S_TYPES], f_type: type[F_TYPES]):

--- a/ninja_aio/models/utils.py
+++ b/ninja_aio/models/utils.py
@@ -328,6 +328,24 @@ class ModelUtil(Generic[ModelT]):
         """
         return self.model._meta.pk.attname
 
+    @cached_property
+    def nested_fields(self) -> dict[str, tuple[type, str]]:
+        """
+        Nested-write configuration for this model's create schema.
+
+        Returns
+        -------
+        dict[str, tuple[type, str]]
+            Mapping of reverse accessor name -> (child_serializer, fk_field_name).
+            Empty when the model has no ``CreateSerializer.nested`` config.
+        """
+        if not isinstance(self.model, ModelSerializerMeta):
+            return {}
+        return {
+            field_name: (child_serializer, self.model._get_nested_fk_field(field_name))
+            for field_name, child_serializer in self.model.get_nested_fields().items()
+        }
+
     @property
     def model_verbose_name(self) -> str:
         """
@@ -1067,8 +1085,8 @@ class ModelUtil(Generic[ModelT]):
 
         Returns
         -------
-        tuple[dict, dict]
-            (payload_without_customs, customs_dict)
+        tuple[dict, dict, dict]
+            (payload_without_customs, customs_dict, nested_data)
 
         Raises
         ------
@@ -1076,6 +1094,14 @@ class ModelUtil(Generic[ModelT]):
             On base64 decoding failure or invalid field names.
         """
         payload = data.model_dump(mode="json")
+
+        # Nested reverse-FK children are lists of dicts, not scalar/FK values -
+        # pull them out before any other field processing sees them.
+        nested_data = {
+            field_name: payload.pop(field_name)
+            for field_name in self.nested_fields
+            if field_name in payload
+        }
 
         is_serializer = (
             isinstance(self.model, ModelSerializerMeta) or self.with_serializer
@@ -1101,9 +1127,14 @@ class ModelUtil(Generic[ModelT]):
         exclude_keys = customs.keys() or optionals
         new_payload = {k: v for k, v in payload.items() if k not in exclude_keys}
 
-        return new_payload, customs
+        return new_payload, customs, nested_data
 
-    async def _create_instance(self, request: HttpRequest, data: Schema):
+    async def _create_instance(
+        self,
+        request: HttpRequest,
+        data: Schema,
+        extra_fields: dict[str, Any] | None = None,
+    ):
         """
         Create a new instance and run hooks.
 
@@ -1115,6 +1146,10 @@ class ModelUtil(Generic[ModelT]):
         request : HttpRequest
         data : Schema
             Input schema instance.
+        extra_fields : dict[str, Any], optional
+            Fields merged into the payload before creation, bypassing schema
+            validation. Used to inject the parent instance's FK when creating
+            a nested child (see ``CreateSerializer.nested``).
 
         Returns
         -------
@@ -1126,7 +1161,9 @@ class ModelUtil(Generic[ModelT]):
         )
 
         logger.info(f"Creating {self.model.__name__}")
-        payload, customs = await self.parse_input_data(request, data)
+        payload, customs, nested_data = await self.parse_input_data(request, data)
+        if extra_fields:
+            payload.update(extra_fields)
         async with suppress_signals():
             obj = (
                 await self.model.objects.acreate(**payload)
@@ -1144,7 +1181,47 @@ class ModelUtil(Generic[ModelT]):
                 self.serializer.custom_actions(customs, obj),
                 self.serializer.post_create(obj),
             )
+        if nested_data:
+            await self._create_nested_children(request, obj, nested_data)
         return obj
+
+    async def _create_nested_children(
+        self, request: HttpRequest, obj: ModelT, nested_data: dict[str, list[dict]]
+    ) -> None:
+        """
+        Create reverse-FK children declared via ``CreateSerializer.nested``.
+
+        Each child payload is re-validated against the child's own create
+        schema and persisted through ``ModelUtil._create_instance`` (so the
+        child's own FK resolution, custom_actions, post_create and reactive
+        hooks all run normally), with the parent's FK injected via
+        ``extra_fields``. Runs inside the caller's transaction (create is
+        already wrapped in ``aatomic``).
+
+        Parameters
+        ----------
+        request : HttpRequest
+        obj : ModelT
+            The newly created parent instance.
+        nested_data : dict[str, list[dict]]
+            Mapping of reverse accessor name -> list of raw child payload dicts.
+        """
+        for field_name, child_payloads in nested_data.items():
+            if not child_payloads:
+                continue
+            child_serializer, fk_field_name = self.nested_fields[field_name]
+            child_util = ModelUtil(child_serializer)
+            child_schema = child_serializer.generate_nested_child_schema(fk_field_name)
+            await asyncio.gather(
+                *[
+                    child_util._create_instance(
+                        request,
+                        child_schema(**child_payload),
+                        extra_fields={fk_field_name: obj},
+                    )
+                    for child_payload in child_payloads
+                ]
+            )
 
     async def create_s(self, request: HttpRequest, data: Schema, obj_schema: Schema):
         """
@@ -1360,7 +1437,7 @@ class ModelUtil(Generic[ModelT]):
 
         logger.info(f"Updating {self.model.__name__} (pk={pk})")
         obj = await self.get_object(request, pk, is_for="read")
-        payload, customs = await self.parse_input_data(request, data)
+        payload, customs, _nested_data = await self.parse_input_data(request, data)
         if require_fields and not payload and not customs:
             raise SerializeError("No fields provided for update.")
 

--- a/tests/generics/models.py
+++ b/tests/generics/models.py
@@ -166,7 +166,7 @@ class Tests:
             )
 
         async def test_parse_input_data(self):
-            payload, customs = await self.model_util.parse_input_data(
+            payload, customs, _ = await self.model_util.parse_input_data(
                 self.request.post(), self.data_in
             )
             self.assertEqual(payload, self.parsed_input_data.get("payload", {}))

--- a/tests/models/test_models_extra.py
+++ b/tests/models/test_models_extra.py
@@ -67,12 +67,12 @@ class ModelUtilParseInputTestCase(TestCase):
 
     async def test_parse_input_custom_and_optional(self):
         data = self.schema_create(name="n", description="d", extra="Z")
-        payload, customs = await self.util_custom.parse_input_data(None, data)
+        payload, customs, _ = await self.util_custom.parse_input_data(None, data)
         self.assertNotIn("extra", payload)
         self.assertEqual(customs["extra"], "Z")
         # optional exclusion when None on update
         upd = self.schema_update()
-        payload_u, customs_u = await self.util_custom.parse_input_data(None, upd)
+        payload_u, customs_u, _ = await self.util_custom.parse_input_data(None, upd)
         self.assertNotIn("description", payload_u)
         self.assertEqual(customs_u, {})
 
@@ -80,7 +80,7 @@ class ModelUtilParseInputTestCase(TestCase):
         data = self.fk_schema_in(
             name="fk", description="fk", test_model_serializer_id=self.fk_rev.pk
         )
-        payload, _ = await self.util_fk.parse_input_data(None, data)
+        payload, _, _ = await self.util_fk.parse_input_data(None, data)
         self.assertIsInstance(
             payload["test_model_serializer"],
             app_models.TestModelSerializerReverseForeignKey,
@@ -104,7 +104,7 @@ class ModelUtilParseInputTestCase(TestCase):
         good_bytes = b"hello"
         b64 = base64.b64encode(good_bytes).decode()
         data_good = schema_in(data=b64)
-        payload, _ = await util.parse_input_data(None, data_good)
+        payload, _, _ = await util.parse_input_data(None, data_good)
         self.assertEqual(payload["data"], good_bytes)
         # bad base64
         data_bad = schema_in(data="$$invalid$$")

--- a/tests/models/test_nested_writes.py
+++ b/tests/models/test_nested_writes.py
@@ -1,0 +1,84 @@
+from django.test import TestCase, tag
+
+from ninja_aio.models import ModelUtil
+from tests.generics.request import Request
+from tests.test_app import models as app_models
+
+
+@tag("nested_writes", "model_util")
+class NestedWritesTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.request = Request("nested-orders/")
+        cls.util = ModelUtil(app_models.NestedOrder)
+        cls.schema_in = app_models.NestedOrder.generate_create_s()
+        cls.schema_out = app_models.NestedOrder.generate_read_s()
+
+    async def test_create_with_nested_children(self):
+        data = self.schema_in(
+            name="order-1",
+            description="d",
+            items=[
+                {"name": "item-1", "description": "d1", "quantity": 2},
+                {"name": "item-2", "description": "d2", "quantity": 5},
+            ],
+        )
+        result = await self.util.create_s(self.request.post(), data, self.schema_out)
+
+        order = await app_models.NestedOrder.objects.aget(pk=result["id"])
+        items = [item async for item in order.items.all()]
+        self.assertEqual(len(items), 2)
+        self.assertEqual({i.name for i in items}, {"item-1", "item-2"})
+        self.assertEqual({i.quantity for i in items}, {2, 5})
+        self.assertTrue(all(i.order_id == order.pk for i in items))
+
+    async def test_create_without_nested_children_defaults_to_empty(self):
+        data = self.schema_in(name="order-2", description="d")
+        result = await self.util.create_s(self.request.post(), data, self.schema_out)
+
+        order = await app_models.NestedOrder.objects.aget(pk=result["id"])
+        self.assertEqual(await order.items.acount(), 0)
+
+    async def test_nested_child_schema_excludes_injected_fk(self):
+        # "order" must not be a required/accepted field on the nested child
+        # schema -- it is injected by the parent, not supplied by the client.
+        fields = self.schema_in.model_fields["items"].annotation
+        child_schema = fields.__args__[0]
+        self.assertNotIn("order", child_schema.model_fields)
+
+    async def test_nested_child_without_explicit_fields_still_excludes_fk(self):
+        # NestedOrderTag declares no CreateSerializer.fields at all -- the
+        # fallback branch must still exclude the injected FK by adding it to
+        # the generated exclude list rather than requiring it.
+        fields = self.schema_in.model_fields["tags"].annotation
+        child_schema = fields.__args__[0]
+        self.assertNotIn("order", child_schema.model_fields)
+
+    async def test_create_with_multiple_nested_relations(self):
+        data = self.schema_in(
+            name="order-4",
+            description="d",
+            items=[{"name": "item-1", "description": "d1", "quantity": 1}],
+            tags=[{"name": "tag-1", "description": "t1"}],
+        )
+        result = await self.util.create_s(self.request.post(), data, self.schema_out)
+
+        order = await app_models.NestedOrder.objects.aget(pk=result["id"])
+        self.assertEqual(await order.items.acount(), 1)
+        self.assertEqual(await order.tags.acount(), 1)
+
+    async def test_nested_child_invalid_payload_rejected_before_persisting(self):
+        # An invalid child value (non-numeric quantity) fails pydantic
+        # validation on the parent's "In" schema itself -- nothing is
+        # persisted since the parent object is never even constructed.
+        with self.assertRaises(Exception):
+            self.schema_in(
+                name="order-3",
+                description="d",
+                items=[
+                    {"name": "bad", "description": "d", "quantity": "not-a-number"}
+                ],
+            )
+        self.assertFalse(
+            await app_models.NestedOrder.objects.filter(name="order-3").aexists()
+        )

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -643,3 +643,55 @@ class PerfArticle(models.Model):
     author = models.ForeignKey(PerfAuthor, on_delete=models.CASCADE)
     category = models.ForeignKey(PerfCategory, on_delete=models.CASCADE)
     publisher = models.ForeignKey(PerfPublisher, on_delete=models.CASCADE)
+
+
+# ==========================================================
+#                  NESTED WRITES MODELS
+# ==========================================================
+
+
+class NestedOrderItem(BaseTestModelSerializer):
+    """Child model created atomically as part of a parent nested write."""
+
+    order = models.ForeignKey(
+        "NestedOrder",
+        on_delete=models.CASCADE,
+        related_name="items",
+    )
+    quantity = models.PositiveIntegerField(default=1)
+
+    class ReadSerializer:
+        fields = BaseTestModelSerializer.ReadSerializer.fields + [
+            "order",
+            "quantity",
+        ]
+
+    class CreateSerializer:
+        # "order" intentionally omitted: it is injected by the nested-write
+        # parent and must not be supplied by the client.
+        fields = BaseTestModelSerializer.CreateSerializer.fields + ["quantity"]
+
+
+class NestedOrderTag(BaseTestModelSerializer):
+    """Child model with no explicit CreateSerializer.fields, exercising the
+    auto-exclude-injected-fk fallback in generate_nested_child_schema()."""
+
+    order = models.ForeignKey(
+        "NestedOrder",
+        on_delete=models.CASCADE,
+        related_name="tags",
+    )
+
+    class CreateSerializer:
+        fields = []
+
+
+class NestedOrder(BaseTestModelSerializer):
+    """Parent model exercising nested creation of NestedOrderItem children."""
+
+    class ReadSerializer:
+        fields = BaseTestModelSerializer.ReadSerializer.fields + ["items"]
+
+    class CreateSerializer:
+        fields = BaseTestModelSerializer.CreateSerializer.fields
+        nested = {"items": NestedOrderItem, "tags": NestedOrderTag}


### PR DESCRIPTION
## Summary
- Adds `CreateSerializer.nested = {"items": ChildSerializer}` so a parent create endpoint can create its reverse-FK children atomically in the same request, e.g. `POST /orders/` with `{"items": [...]}`.
- The child's FK back to the parent is auto-excluded from the generated nested input schema and injected at creation time. Each child still runs through its own full create pipeline (validators, `custom_actions`, `post_create`, reactive hooks).
- Create-only by design — updating a collection of children (replace/merge/diff-by-pk) has ambiguous semantics, so it's intentionally out of scope. Runs inside the existing `aatomic()` transaction.
- M2M relations remain out of scope: `ManyToManyAPI` already covers linking *existing* rows, which is a different operation from creating owned children.

## Changes
- `ninja_aio/models/serializers.py` — `CreateSerializer.nested`, `get_nested_fields()`, `get_nested_customs()`, `generate_nested_child_schema()`, `_get_nested_fk_field()`.
- `ninja_aio/models/utils.py` — `ModelUtil.nested_fields`, `parse_input_data()` now returns `(payload, customs, nested)`, `_create_instance(extra_fields=...)`, `_create_nested_children()`.
- `docs/api/models/model_serializer.md` — new "Nested Writes" section with a worked `Order`/`OrderItem` example.
- `tests/test_app/models.py`, `tests/models/test_nested_writes.py` — new fixtures + 6 tests covering creation, empty defaults, FK auto-exclusion (both code paths), multiple nested relations, invalid payload rejection.
- `TODO.md` — moved item to Completed.

## Test plan
- [x] `./run-tests.sh` — 1006/1006 pass
- [x] `coverage run -m django test` — 100% coverage on both touched source files
- [x] 5-run performance regression check (`detect_regression.py`) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)