### PR TITLE
feat: auto-generate admin inlines and M2M widgets from relation graph

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,7 @@
 | 26 | ~~NinjaAIORouter~~ | `ninja_aio/router.py`, `ninja_aio/api.py` | v2.32.0 | Composable router with `.view()` and `.viewset()` decorators. Attach via `api.add_router()` or `@api.router()`. Enables versioned and domain-separated API layouts. |
 | 27 | ~~Field selection~~ | `ninja_aio/views/mixins.py` | v2.33.0 | `FieldSelectionViewSetMixin` — `?fields=id,name,email` on list and retrieve. Reduces payload. Unknown field names ignored; falls back to full response. |
 | 28 | ~~`@on` detail action shorthand~~ | `ninja_aio/decorators/actions.py`, `ninja_aio/views/api.py` | v2.33.0 | `@on("publish")` pre-fetches the object, runs `on_before_operation` + `on_before_object_operation`, passes `obj` to the handler — zero boilerplate. |
+| 30 | ~~Auto admin inlines~~ | `ninja_aio/admin.py` | unreleased | `@register_admin` / `as_admin()` auto-generate `TabularInline` (reverse FK) / `StackedInline` (reverse O2O) and `filter_horizontal` (forward M2M, skipped for custom `through` models) from the model's Django relation graph. Inline field lists prefer the child's `UpdateSerializer.fields`, always drop the injected parent FK, and fall back to Django's defaults for plain (non-`ModelSerializer`) children. Override via `inlines=(...)` / `filter_horizontal=(...)` like any other `register_admin` kwarg. |
 
 ---
 
@@ -47,7 +48,6 @@
 | 25 | Aggregation endpoints | `views/mixins.py` | `AggregationViewSetMixin` — COUNT, SUM, AVG, MIN, MAX on list views for dashboards. |
 | 27 | Nested writes | `models/utils.py`, `views/api.py` | Create parent + children in one atomic request. `POST /order` with `{"items": [...]}`. |
 | 28 | File upload mixin | `views/mixins.py` | `FileUploadViewSetMixin` — `POST /{pk}/upload` with `multipart/form-data`, configurable storage (local, S3). |
-| 29 | Auto admin inlines | `admin.py` | Extend `@register_admin` to auto-generate `InlineModelAdmin` for FK/M2M relations. |
 | 30 | Admin actions from ViewSet | `admin.py` | `@action` endpoints become available as Django Admin actions. `@action("publish")` → admin "Publish selected" action. |
 | 31 | ETag / Conditional requests | `views/api.py` | HTTP caching with `ETag`, `If-None-Match`, `If-Modified-Since` on retrieve/list. |
 | 32 | Deadlock retry in `aatomic` | `decorators/views.py` | Configurable exponential backoff with deadlock detection. |

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -34,6 +34,8 @@ This auto-generates:
 | `search_fields` | `("title", "synopsis")` |
 | `list_filter` | `("author", "published")` |
 | `readonly_fields` | `("author", "published")` |
+| `inlines` | One `TabularInline`/`StackedInline` per reverse FK/O2O relation (e.g. `Chapter` if it has a FK to `Book`) |
+| `filter_horizontal` | One entry per forward `ManyToManyField` declared on `Book` |
 
 ### Option 2: `Model.as_admin()`
 
@@ -67,6 +69,73 @@ Override any auto-generated attribute:
     list_display=("title", "author"),  # Override auto list_display
     search_fields=("title", "author__name"),  # Add relation search
 )
+class Book(ModelSerializer): ...
+```
+
+---
+
+## Relations: Inlines & M2M Widgets
+
+`@register_admin` / `Model.as_admin()` also inspect the model's Django
+relation graph and wire up sensible relation widgets automatically — no
+separate `TabularInline` classes to write for the common case.
+
+- **Reverse ForeignKey** → `TabularInline` (a child editable in a table on
+  the parent's change page).
+- **Reverse OneToOne** → `StackedInline` (a single child form, since there's
+  at most one).
+- **Forward ManyToManyField** → `filter_horizontal` (Django's dual-list
+  widget), unless the field uses a custom `through` model with extra fields
+  (Django doesn't support `filter_horizontal` for those, so they're left for
+  you to configure explicitly).
+- **Reverse ManyToMany** is skipped — there's no owning FK to inline against.
+
+```python
+@register_admin
+class Book(ModelSerializer):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+    tags = models.ManyToManyField(Tag)
+
+    class ReadSerializer:
+        fields = ["id", "author", "tags"]
+
+@register_admin
+class Chapter(ModelSerializer):
+    book = models.ForeignKey(Book, on_delete=models.CASCADE, related_name="chapters")
+    title = models.CharField(max_length=200)
+    number = models.PositiveIntegerField()
+
+    class ReadSerializer:
+        fields = ["id", "book", "title", "number"]
+
+    class UpdateSerializer:
+        fields = ["title", "number"]
+```
+
+Opening `Book` in the admin now shows a `Chapters` inline table (fields
+`title`, `number` — taken from `Chapter.UpdateSerializer.fields`, since
+that's what should be editable in place) and a dual-list widget for `tags`.
+No `admin.py` boilerplate required.
+
+**The inline's field list:**
+
+- Uses the child's `UpdateSerializer.fields` when defined, falling back to
+  `CreateSerializer.fields`.
+- Always drops the FK field pointing back at the parent (`book` above) — it
+  is supplied via Django's inline formset (`fk_name`), so listing it
+  explicitly raises a `FieldError`.
+- Falls back to Django Admin's own default (all editable fields) for plain
+  (non-`ModelSerializer`) child models.
+
+**Overriding:** pass `inlines=(...)` or `filter_horizontal=(...)` like any
+other override — it replaces the auto-generated value entirely:
+
+```python
+@register_admin(inlines=(MyCustomChapterInline,))
+class Book(ModelSerializer): ...
+
+# Disable auto-inlines entirely
+@register_admin(inlines=())
 class Book(ModelSerializer): ...
 ```
 

--- a/ninja_aio/admin.py
+++ b/ninja_aio/admin.py
@@ -96,6 +96,73 @@ def _classify_fields(model: type) -> dict:
     }
 
 
+def _inline_fields(child_model: type, fk_field_name: str) -> tuple[str, ...] | None:
+    """
+    Fields to display on an auto-generated inline for a reverse FK/O2O child.
+
+    Prefers `UpdateSerializer` fields (what should be editable in place),
+    falling back to `CreateSerializer` fields when the child has no
+    `UpdateSerializer`. The FK field back to the parent is always dropped --
+    Django's inline formset excludes it from the form already (it's supplied
+    via `fk_name`), so listing it explicitly would raise a `FieldError`.
+    Returns None for plain Django models, letting Django Admin fall back to
+    its own default (all editable fields).
+    """
+    if not isinstance(child_model, ModelSerializerMeta):
+        return None
+    names = list(
+        dict.fromkeys(child_model.get_fields("update") or child_model.get_fields("create"))
+    )
+    names = [n for n in names if n != fk_field_name]
+    return tuple(names) or None
+
+
+def _build_inline(rel) -> type[admin.TabularInline]:
+    """Build a TabularInline/StackedInline class for one reverse FK/O2O relation."""
+    child_model = rel.related_model
+    fk_field_name = rel.field.name
+    base = admin.StackedInline if rel.one_to_one else admin.TabularInline
+    attrs: dict = {"model": child_model, "fk_name": fk_field_name, "extra": 0}
+    fields = _inline_fields(child_model, fk_field_name)
+    if fields:
+        attrs["fields"] = fields
+    return type(f"{child_model.__name__}Inline", (base,), attrs)
+
+
+def _is_plain_m2m(field: ManyToManyField) -> bool:
+    """
+    Check a M2M field uses Django's auto-created through table.
+
+    `filter_horizontal` raises a admin.E013 check error for M2M fields with a
+    custom `through` model carrying extra fields, so those are left alone.
+    """
+    return bool(getattr(field.remote_field.through._meta, "auto_created", False))
+
+
+def _classify_relations(model: type) -> dict:
+    """
+    Derive Django Admin relation config from the model's Django relation graph.
+
+    - Reverse FK relations (other models pointing a FK at this one) become
+      `TabularInline`; reverse one-to-one becomes `StackedInline`. Reverse
+      M2M is skipped -- there's no owning FK to inline against.
+    - Forward M2M fields declared on this model get `filter_horizontal`'s
+      dual-list widget, unless they use a custom `through` model.
+    """
+    inlines = [
+        _build_inline(rel)
+        for rel in model._meta.related_objects
+        if not rel.many_to_many
+    ]
+    filter_horizontal = tuple(
+        f.name for f in model._meta.many_to_many if _is_plain_m2m(f)
+    )
+    return {
+        "inlines": tuple(inlines),
+        "filter_horizontal": filter_horizontal,
+    }
+
+
 def model_admin_factory(model: type, **overrides) -> type[admin.ModelAdmin]:
     """
     Create a ModelAdmin class from a ModelSerializer's field config.
@@ -104,8 +171,13 @@ def model_admin_factory(model: type, **overrides) -> type[admin.ModelAdmin]:
 
         AdminClass = model_admin_factory(Book, list_per_page=50)
         admin.site.register(Book, AdminClass)
+
+    Reverse FK/O2O relations are auto-registered as inlines and forward M2M
+    fields get the `filter_horizontal` widget -- pass `inlines=(...)` or
+    `filter_horizontal=(...)` to override either.
     """
     config = _classify_fields(model)
+    config.update(_classify_relations(model))
     config.update(overrides)
     return type(f"{model.__name__}Admin", (admin.ModelAdmin,), config)
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,7 +2,12 @@ from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.test import TestCase, tag
 
-from ninja_aio.admin import _classify_fields, model_admin_factory, register_admin
+from ninja_aio.admin import (
+    _classify_fields,
+    _classify_relations,
+    model_admin_factory,
+    register_admin,
+)
 from tests.test_app import models
 
 
@@ -185,3 +190,76 @@ class AsAdminTestCase(TestCase):
     def test_fk_model_as_admin(self):
         admin_cls = models.TestModelSerializerForeignKey.as_admin()
         self.assertIn("test_model_serializer", admin_cls.list_filter)
+
+
+@tag("admin")
+class ClassifyRelationsTestCase(TestCase):
+    """Test _classify_relations auto-generates inlines and filter_horizontal."""
+
+    def test_reverse_fk_becomes_tabular_inline(self):
+        config = _classify_relations(models.TestModelSerializerReverseForeignKey)
+        inline_models = {inl.model for inl in config["inlines"]}
+        self.assertIn(models.TestModelSerializerForeignKey, inline_models)
+        inline = next(
+            inl
+            for inl in config["inlines"]
+            if inl.model is models.TestModelSerializerForeignKey
+        )
+        self.assertTrue(issubclass(inline, admin.TabularInline))
+        self.assertEqual(inline.fk_name, "test_model_serializer")
+
+    def test_reverse_one_to_one_becomes_stacked_inline(self):
+        config = _classify_relations(models.TestModelSerializerReverseOneToOne)
+        inline = next(
+            inl
+            for inl in config["inlines"]
+            if inl.model is models.TestModelSerializerOneToOne
+        )
+        self.assertTrue(issubclass(inline, admin.StackedInline))
+        self.assertEqual(inline.fk_name, "test_model_serializer")
+
+    def test_inline_excludes_fk_field_from_fields(self):
+        config = _classify_relations(models.TestModelSerializerReverseForeignKey)
+        inline = next(
+            inl
+            for inl in config["inlines"]
+            if inl.model is models.TestModelSerializerForeignKey
+        )
+        self.assertNotIn("test_model_serializer", inline.fields or ())
+
+    def test_plain_model_child_uses_admin_default_fields(self):
+        """A reverse FK from a plain (non-ModelSerializer) model should get
+        an inline with no explicit `fields`, letting Django Admin show all
+        editable fields by default."""
+        config = _classify_relations(models.TestModelSerializer)
+        inline = next(
+            inl
+            for inl in config["inlines"]
+            if inl.model is models.AdminInlinePlainChild
+        )
+        self.assertIsNone(inline.fields)
+
+    def test_reverse_m2m_has_no_inline(self):
+        config = _classify_relations(models.TestModelSerializerReverseManyToMany)
+        inline_models = {inl.model for inl in config["inlines"]}
+        self.assertNotIn(models.TestModelSerializerManyToMany, inline_models)
+
+    def test_forward_m2m_gets_filter_horizontal(self):
+        config = _classify_relations(models.TestModelSerializerManyToMany)
+        self.assertIn("test_model_serializers", config["filter_horizontal"])
+
+    def test_no_relations_is_empty(self):
+        config = _classify_relations(models.TestModelSerializerWithReadOptionals)
+        self.assertEqual(config["inlines"], ())
+        self.assertEqual(config["filter_horizontal"], ())
+
+    def test_model_admin_factory_wires_inlines(self):
+        admin_cls = model_admin_factory(models.TestModelSerializerReverseForeignKey)
+        inline_models = {inl.model for inl in admin_cls.inlines}
+        self.assertIn(models.TestModelSerializerForeignKey, inline_models)
+
+    def test_overrides_replace_auto_inlines(self):
+        admin_cls = model_admin_factory(
+            models.TestModelSerializerReverseForeignKey, inlines=()
+        )
+        self.assertEqual(admin_cls.inlines, ())

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -643,3 +643,18 @@ class PerfArticle(models.Model):
     author = models.ForeignKey(PerfAuthor, on_delete=models.CASCADE)
     category = models.ForeignKey(PerfCategory, on_delete=models.CASCADE)
     publisher = models.ForeignKey(PerfPublisher, on_delete=models.CASCADE)
+
+
+# ==========================================================
+#                  AUTO ADMIN INLINE MODELS
+# ==========================================================
+
+
+class AdminInlinePlainChild(models.Model):
+    """Plain (non-ModelSerializer) reverse-FK child of TestModelSerializer,
+    exercising the default-admin-fields fallback in _inline_fields()."""
+
+    parent = models.ForeignKey(
+        TestModelSerializer, on_delete=models.CASCADE, related_name="plain_children"
+    )
+    label = models.CharField(max_length=50)


### PR DESCRIPTION
## Summary
- Extends `@register_admin` / `Model.as_admin()` to auto-generate Django Admin relation widgets from the model's Django relation graph, no `admin.py` boilerplate:
  - Reverse FK → `TabularInline`; reverse one-to-one → `StackedInline`. `fk_name` is always set explicitly, which also disambiguates the case of multiple FKs from the same child model.
  - Forward `ManyToManyField` → `filter_horizontal`, skipped for fields using a custom `through` model with extra fields (Django doesn't support `filter_horizontal` there).
  - Reverse M2M is skipped — there's no owning FK to inline against.
- Inline field lists prefer the child's `UpdateSerializer.fields` (falling back to `CreateSerializer.fields`), always drop the FK back to the parent (supplied via `fk_name`, so listing it would raise a `FieldError`), and fall back to Django's own defaults for plain (non-`ModelSerializer`) children.
- Fully overridable: pass `inlines=(...)` or `filter_horizontal=(...)` like any other `register_admin`/`as_admin` kwarg to replace the auto-generated value, including disabling entirely with `inlines=()`.

## Changes
- `ninja_aio/admin.py` — `_classify_relations()`, `_build_inline()`, `_inline_fields()`, `_is_plain_m2m()`, wired into `model_admin_factory()`.
- `docs/api/admin.md` — new "Relations: Inlines & M2M Widgets" section with a `Book`/`Chapter` example.
- `tests/test_app/models.py`, `tests/test_admin.py` — new fixture + 9 tests covering reverse FK/O2O/M2M classification, FK exclusion from inline fields, plain-model fallback, and override behavior.
- `TODO.md` — moved item to Completed.

## Test plan
- [x] `./run-tests.sh` — 1009/1009 pass
- [x] `coverage run -m django test` — 100% coverage on `ninja_aio/admin.py`
- [x] Manually verified against Django's admin system checks (`ModelAdmin.check()`) for FK, O2O, and M2M fixture pairs — no new check errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)