### PR TITLE
fix: eliminate three redundant-query patterns in read/bulk/delete paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # 📋 Release Notes
 
+## 🏷️ [v2.34.2] - 2026-08-13
+
+---
+
+### 🐛 Bug Fix
+
+#### ⚡ N+1 query on every list/retrieve using `select_related`/`prefetch_related`
+> `ninja_aio/models/utils.py`
+
+`_get_base_queryset` applied the `read`/`detail`-scoped `select_related`/`prefetch_related` optimizations and then unconditionally replaced the queryset with whatever the default `queryset_request` hook returned — silently discarding those optimizations for any `ModelSerializer` that declares `QuerySet.read`/`QuerySet.detail` without also duplicating the same config under `QuerySet.queryset_request`. Every row with a serialized relation field paid one extra query. Fixed by applying the scoped optimizations *after* the hook runs, on top of its result (`select_related`/`prefetch_related` are additive, so this is safe either way).
+
+Profiled repro (300 list calls, 50 rows/page, one relation field): **3.54s → 0.635s (~5.6x faster)**. Benchmark suite: `FilterPerformanceTest.relation_filter` **-63.09%** (2.72ms → 1.00ms).
+
+---
+
+#### ⚡ Duplicate FK resolution query on every item in bulk create/update
+> `ninja_aio/models/utils.py`
+
+`_resolve_fk` re-resolved a foreign key ID to its related instance independently for every item in a `bulk_create_s`/`bulk_update_s` batch, even when many items shared the same FK value (e.g. a batch of rows all pointing at the same category or tenant). Fixed with a request-scoped `fk_cache` dict shared across the items of a single bulk call — a repeated `(model, pk)` pair now resolves once instead of once per item. Single `create_s`/`update_s` calls are unaffected (`fk_cache=None` by default).
+
+Benchmark suite: `MultiFKPerformanceTest.bulk_create_50x3fk` **-33.01%** (26.35ms → 17.66ms).
+
+---
+
+#### ⚡ Duplicate object fetch on delete when `schema_delete_out` is set
+> `ninja_aio/views/api.py`, `ninja_aio/models/utils.py`
+
+`delete_view` fetched the target object once to serialize it for the `schema_delete_out` response, then `delete_s` fetched the *same* object again internally just to call `.adelete()` on it. `delete_s` now accepts an optional `instance=` — when the caller already has the object, it deletes it directly instead of re-querying. Default behavior (`instance=None`, used by `hard_delete`, plain `DELETE`, and every other caller) is unchanged. Verified via a `get_object` call-count spy: 2 → 1 fetch per request.
+
+---
+
+### 🎯 Summary
+
+Three targeted bug fixes, all the same shape: redundant or dropped database work in the framework's own query/serialization glue, found and confirmed with `cProfile` and the project's own benchmark suite rather than assumed. No public API changes; all fixes are backward compatible (new parameters default to prior behavior).
+
+**Key benefits:**
+- ⚡ List/retrieve endpoints serializing relations no longer pay an extra query per row
+- ⚡ Bulk create/update with repeated FK values no longer re-resolves the same related object per item
+- ⚡ Delete-with-response (`schema_delete_out`) no longer fetches the object twice
+- ✅ Full regression coverage added for all three fixes; 100% coverage maintained on both changed files; zero performance regressions detected by the statistical regression tool
+
+---
+
 ## 🏷️ [v2.34.1] - 2026-08-12
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,9 @@
 | 27 | ~~Field selection~~ | `ninja_aio/views/mixins.py` | v2.33.0 | `FieldSelectionViewSetMixin` — `?fields=id,name,email` on list and retrieve. Reduces payload. Unknown field names ignored; falls back to full response. |
 | 28 | ~~`@on` detail action shorthand~~ | `ninja_aio/decorators/actions.py`, `ninja_aio/views/api.py` | v2.33.0 | `@on("publish")` pre-fetches the object, runs `on_before_operation` + `on_before_object_operation`, passes `obj` to the handler — zero boilerplate. |
 | 29 | ~~AI Agent Integration (MCP)~~ | `ninja_aio/mcp/`, `ninja_aio/apps.py`, `ninja_aio/management/` | v2.34.0 | Exposes registered `APIViewSet`s (CRUD, bulk, `@action`/`@on`) and `APIView`s as MCP tools for any MCP client. `NinjaAIOMCPServer`/`run_mcp_server`, `python manage.py mcp_server`. |
+| 30 | ~~Performance: dropped select_related/prefetch_related~~ | `models/utils.py` | v2.34.2 | `queryset_request` hook no longer discards read/detail-scoped query optimizations; fixed N+1 on list/retrieve with relations. |
+| 31 | ~~Performance: duplicate FK resolution in bulk ops~~ | `models/utils.py` | v2.34.2 | Request-scoped `fk_cache` dedupes repeated FK lookups across a `bulk_create_s`/`bulk_update_s` batch. |
+| 32 | ~~Performance: duplicate fetch on delete~~ | `views/api.py`, `models/utils.py` | v2.34.2 | `delete_s(instance=...)` skips the redundant re-fetch when `schema_delete_out` is set. |
 
 ---
 

--- a/ninja_aio/__init__.py
+++ b/ninja_aio/__init__.py
@@ -1,6 +1,6 @@
 """Django Ninja AIO CRUD - Rest Framework"""
 
-__version__ = "2.34.1"
+__version__ = "2.34.2"
 
 __all__ = ["NinjaAIO", "NinjaAIORouter", "register_admin", "Branding"]
 

--- a/ninja_aio/models/utils.py
+++ b/ninja_aio/models/utils.py
@@ -427,12 +427,18 @@ class ModelUtil(Generic[ModelT]):
             else await self.serializer_class.queryset_request(request)
         )
 
-        # Apply query optimizations
-        obj_qs = self._apply_query_optimizations(obj_qs, query_data, is_for)
-
-        # Apply queryset_request hook if available
+        # Apply queryset_request hook if available. This may return an entirely
+        # different queryset (e.g. request-scoped filtering), so it must run
+        # before the read/detail-scoped optimizations below, or those would be
+        # silently discarded.
         if isinstance(self.model, ModelSerializerMeta) and with_qs_request:
             obj_qs = await self.model.queryset_request(request)
+
+        # Apply query optimizations for the requested scope. select_related/
+        # prefetch_related are additive, so re-applying them here on top of
+        # whatever the hook returned is safe even if it already optimized
+        # for its own (queryset_request) scope.
+        obj_qs = self._apply_query_optimizations(obj_qs, query_data, is_for)
 
         # Apply filters if present (supports dict or Q object)
         if hasattr(query_data, "filters") and query_data.filters:
@@ -969,6 +975,7 @@ class ModelUtil(Generic[ModelT]):
         k: str,
         v: Any,
         field_obj: models.ForeignKey,
+        fk_cache: dict[tuple[type, Any], Any] | None = None,
     ) -> None:
         """Resolve foreign key ID to model instance in place.
 
@@ -988,33 +995,50 @@ class ModelUtil(Generic[ModelT]):
         In every scoped path, a row outside the caller's scope raises the
         standard ``NotFoundError(rel_model)`` — indistinguishable from a real
         404, so cross-tenant probing cannot leak existence.
+
+        Parameters
+        ----------
+        fk_cache : dict[tuple[type, Any], Any], optional
+            Request-scoped cache of already-resolved ``(rel_model, pk)`` ->
+            instance pairs, shared across the items of a single bulk
+            create/update call. Avoids re-fetching the same related object
+            once per item when the same FK value repeats across the batch.
+            ``None`` (the default, used by single create/update) disables
+            caching entirely.
         """
         rel_model = field_obj.related_model
+        cache_key = (rel_model, v) if fk_cache is not None else None
+        if cache_key is not None and cache_key in fk_cache:
+            payload[k] = fk_cache[cache_key]
+            return
+
         logger.debug(
             f"Resolving FK '{k}' -> {rel_model.__name__} (pk={v}) for {self.model.__name__}"
         )
 
         if isinstance(rel_model, ModelSerializerMeta):
             payload[k] = await ModelUtil(rel_model).get_object(request, pk=v)
-            return
-
-        rel_serializer_cls = get_serializer_for_model(rel_model)
-        if rel_serializer_cls is not None:
+        elif (
+            rel_serializer_cls := get_serializer_for_model(rel_model)
+        ) is not None:
             payload[k] = await ModelUtil(
                 rel_model, serializer_class=rel_serializer_cls
             ).get_object(request, pk=v)
-            return
+        else:
+            try:
+                payload[k] = await rel_model.objects.aget(pk=v)
+            except rel_model.DoesNotExist:
+                raise NotFoundError(rel_model)
 
-        try:
-            payload[k] = await rel_model.objects.aget(pk=v)
-        except rel_model.DoesNotExist:
-            raise NotFoundError(rel_model)
+        if cache_key is not None:
+            fk_cache[cache_key] = payload[k]
 
     async def _process_payload_fields(
         self,
         request: HttpRequest,
         payload: dict,
         fields_to_process: list[tuple[str, Any]],
+        fk_cache: dict[tuple[type, Any], Any] | None = None,
     ) -> None:
         """
         Process payload fields: decode binary and resolve foreign keys.
@@ -1030,6 +1054,8 @@ class ModelUtil(Generic[ModelT]):
             Payload dict to modify in place.
         fields_to_process : list[tuple[str, Any]]
             List of (field_name, field_value) tuples to process.
+        fk_cache : dict[tuple[type, Any], Any], optional
+            Request-scoped FK resolution cache, see ``_resolve_fk``.
         """
         if not fields_to_process:
             return
@@ -1042,12 +1068,19 @@ class ModelUtil(Generic[ModelT]):
         for (k, v), field_obj in zip(fields_to_process, field_objs):
             self._decode_binary(payload, k, v, field_obj)
             if isinstance(field_obj, models.ForeignKey) and v is not None:
-                fk_tasks.append(self._resolve_fk(request, payload, k, v, field_obj))
+                fk_tasks.append(
+                    self._resolve_fk(request, payload, k, v, field_obj, fk_cache)
+                )
 
         if fk_tasks:
             await asyncio.gather(*fk_tasks)
 
-    async def parse_input_data(self, request: HttpRequest, data: Schema):
+    async def parse_input_data(
+        self,
+        request: HttpRequest,
+        data: Schema,
+        fk_cache: dict[tuple[type, Any], Any] | None = None,
+    ):
         """
         Transform inbound schema data to a model-ready payload.
 
@@ -1064,6 +1097,9 @@ class ModelUtil(Generic[ModelT]):
         request : HttpRequest
         data : Schema
             Incoming validated schema instance.
+        fk_cache : dict[tuple[type, Any], Any], optional
+            Request-scoped cache of already-resolved FK instances, shared
+            across items of a bulk create/update call. See ``_resolve_fk``.
 
         Returns
         -------
@@ -1095,7 +1131,9 @@ class ModelUtil(Generic[ModelT]):
 
         # Process payload fields - gather field objects in parallel for better performance
         fields_to_process = [(k, v) for k, v in payload.items() if k not in skip_keys]
-        await self._process_payload_fields(request, payload, fields_to_process)
+        await self._process_payload_fields(
+            request, payload, fields_to_process, fk_cache
+        )
 
         # Preserve original exclusion semantics (customs if present else optionals)
         exclude_keys = customs.keys() or optionals
@@ -1103,7 +1141,12 @@ class ModelUtil(Generic[ModelT]):
 
         return new_payload, customs
 
-    async def _create_instance(self, request: HttpRequest, data: Schema):
+    async def _create_instance(
+        self,
+        request: HttpRequest,
+        data: Schema,
+        fk_cache: dict[tuple[type, Any], Any] | None = None,
+    ):
         """
         Create a new instance and run hooks.
 
@@ -1115,6 +1158,9 @@ class ModelUtil(Generic[ModelT]):
         request : HttpRequest
         data : Schema
             Input schema instance.
+        fk_cache : dict[tuple[type, Any], Any], optional
+            Request-scoped cache of already-resolved FK instances, shared
+            across items of a bulk create call. See ``_resolve_fk``.
 
         Returns
         -------
@@ -1126,7 +1172,7 @@ class ModelUtil(Generic[ModelT]):
         )
 
         logger.info(f"Creating {self.model.__name__}")
-        payload, customs = await self.parse_input_data(request, data)
+        payload, customs = await self.parse_input_data(request, data, fk_cache)
         async with suppress_signals():
             obj = (
                 await self.model.objects.acreate(**payload)
@@ -1332,6 +1378,7 @@ class ModelUtil(Generic[ModelT]):
         data: Schema,
         pk: int | str,
         require_fields: bool = False,
+        fk_cache: dict[tuple[type, Any], Any] | None = None,
     ):
         """
         Update an existing instance and run hooks.
@@ -1348,6 +1395,9 @@ class ModelUtil(Generic[ModelT]):
             Primary key of target object.
         require_fields : bool
             When True, raises SerializeError if no fields are provided.
+        fk_cache : dict[tuple[type, Any], Any], optional
+            Request-scoped cache of already-resolved FK instances, shared
+            across items of a bulk update call. See ``_resolve_fk``.
 
         Returns
         -------
@@ -1360,7 +1410,7 @@ class ModelUtil(Generic[ModelT]):
 
         logger.info(f"Updating {self.model.__name__} (pk={pk})")
         obj = await self.get_object(request, pk, is_for="read")
-        payload, customs = await self.parse_input_data(request, data)
+        payload, customs = await self.parse_input_data(request, data, fk_cache)
         if require_fields and not payload and not customs:
             raise SerializeError("No fields provided for update.")
 
@@ -1426,7 +1476,9 @@ class ModelUtil(Generic[ModelT]):
         )
         return await self.read_s(obj_schema, request, updated_object)
 
-    async def delete_s(self, request: HttpRequest, pk: int | str):
+    async def delete_s(
+        self, request: HttpRequest, pk: int | str, instance: ModelT | None = None
+    ):
         """
         Delete an instance by primary key.
 
@@ -1435,6 +1487,11 @@ class ModelUtil(Generic[ModelT]):
         request : HttpRequest
         pk : int | str
             Primary key.
+        instance : ModelT, optional
+            Already-fetched instance to delete. When provided, skips the
+            lookup query entirely (e.g. the caller already fetched the object
+            to serialize it before deletion, as ``delete_view`` does when
+            ``schema_delete_out`` is set).
 
         Returns
         -------
@@ -1445,7 +1502,7 @@ class ModelUtil(Generic[ModelT]):
         )
 
         logger.info(f"Deleting {self.model.__name__} (pk={pk})")
-        obj = await self.get_object(request, pk)
+        obj = instance if instance is not None else await self.get_object(request, pk)
         async with suppress_signals():
             await obj.adelete()
         logger.debug(f"Deleted {self.model.__name__} (pk={pk})")
@@ -1509,10 +1566,14 @@ class ModelUtil(Generic[ModelT]):
         extractor = detail_extractor or (lambda obj: obj.pk)
         success_details = []
         error_details = []
+        # Request-scoped cache: repeated FK values across items in the batch
+        # (e.g. many rows sharing the same category/tenant) are resolved once
+        # instead of once per item. See `_resolve_fk`.
+        fk_cache: dict[tuple[type, Any], Any] = {}
 
         for data in data_list:
             try:
-                obj = await self._create_instance(request, data)
+                obj = await self._create_instance(request, data, fk_cache)
                 success_details.append(extractor(obj))
             except (SerializeError, NotFoundError) as e:
                 error_details.append(self._format_bulk_error(e))
@@ -1558,11 +1619,14 @@ class ModelUtil(Generic[ModelT]):
         extractor = detail_extractor or (lambda obj: obj.pk)
         success_details = []
         error_details = []
+        # Request-scoped cache: repeated FK values across items in the batch
+        # are resolved once instead of once per item. See `_resolve_fk`.
+        fk_cache: dict[tuple[type, Any], Any] = {}
 
         for pk, data in data_list:
             try:
                 obj = await self._update_instance(
-                    request, data, pk, require_fields
+                    request, data, pk, require_fields, fk_cache
                 )
                 success_details.append(extractor(obj))
             except (SerializeError, NotFoundError) as e:

--- a/ninja_aio/views/api.py
+++ b/ninja_aio/views/api.py
@@ -934,7 +934,7 @@ class APIViewSet(API, Generic[ModelT]):
             if _delete_schema:
                 obj = await self.model_util.get_object(request, _pk)
                 serialized = await self.model_util.read_s(_delete_schema, request, obj)
-                await self.model_util.delete_s(request, _pk)
+                await self.model_util.delete_s(request, _pk, instance=obj)
                 return Status(200, serialized)
             return Status(
                 204, await self.model_util.delete_s(request, _pk)

--- a/tests/models/test_fk_optimization.py
+++ b/tests/models/test_fk_optimization.py
@@ -5,13 +5,46 @@ This module tests that the FK resolution optimization in create_s and update_s
 maintains correct functionality while reducing redundant database queries.
 """
 
+from contextlib import contextmanager
 from unittest import mock
 
 from django.test import TestCase, tag
 from asgiref.sync import async_to_sync
+from ninja import Schema
 
 from tests.test_app import models
 from ninja_aio.models import ModelUtil
+
+
+class _FKCreateSchema(Schema):
+    name: str
+    description: str
+    test_model_serializer: int
+
+
+class _FKUpdateSchema(Schema):
+    name: str | None = None
+    description: str | None = None
+    test_model_serializer: int | None = None
+
+
+@contextmanager
+def _count_fk_resolutions(target_model):
+    """Patch ModelUtil.get_object to record every pk resolved for
+    `target_model`, without altering the real resolution behavior.
+
+    Yields the list of resolved pks, appended to in call order.
+    """
+    resolved_pks = []
+    original_get_object = ModelUtil.get_object
+
+    async def counting_get_object(self, request, pk=None, **kwargs):
+        if self.model is target_model:
+            resolved_pks.append(pk)
+        return await original_get_object(self, request, pk=pk, **kwargs)
+
+    with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+        yield resolved_pks
 
 
 @tag("fk_optimization")
@@ -386,36 +419,18 @@ class BulkFKCacheOptimizationTestCase(TestCase):
     async def test_bulk_create_dedupes_repeated_fk_resolution(self):
         """10 items sharing the same FK value must resolve that FK once, not
         once per item."""
-        from django.http import HttpRequest
-        from ninja import Schema
-
-        class CreateSchema(Schema):
-            name: str
-            description: str
-            test_model_serializer: int
-
-        request = HttpRequest()
-        resolved_pks = []
-        original_get_object = ModelUtil.get_object
-
-        async def counting_get_object(self, request, pk=None, **kwargs):
-            if self.model is models.TestModelSerializerReverseForeignKey:
-                resolved_pks.append(pk)
-            return await original_get_object(self, request, pk=pk, **kwargs)
-
+        request = mock.Mock()
         data_list = [
-            CreateSchema(
-                name=f"item_{i}",
-                description="d",
-                test_model_serializer=self.rev_fk_1.id,
+            _FKCreateSchema(
+                name=f"item_{i}", description="d", test_model_serializer=self.rev_fk_1.id
             )
             for i in range(10)
         ]
 
-        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
-            success, errors = await self.model_util.bulk_create_s(
-                request, data_list
-            )
+        with _count_fk_resolutions(
+            models.TestModelSerializerReverseForeignKey
+        ) as resolved_pks:
+            success, errors = await self.model_util.bulk_create_s(request, data_list)
 
         self.assertEqual(errors, [])
         self.assertEqual(len(success), 10)
@@ -426,25 +441,9 @@ class BulkFKCacheOptimizationTestCase(TestCase):
     async def test_bulk_create_resolves_each_distinct_fk_once(self):
         """Two distinct FK values across a batch must each resolve exactly
         once, regardless of how many items reference them."""
-        from django.http import HttpRequest
-        from ninja import Schema
-
-        class CreateSchema(Schema):
-            name: str
-            description: str
-            test_model_serializer: int
-
-        request = HttpRequest()
-        resolved_pks = []
-        original_get_object = ModelUtil.get_object
-
-        async def counting_get_object(self, request, pk=None, **kwargs):
-            if self.model is models.TestModelSerializerReverseForeignKey:
-                resolved_pks.append(pk)
-            return await original_get_object(self, request, pk=pk, **kwargs)
-
+        request = mock.Mock()
         data_list = [
-            CreateSchema(
+            _FKCreateSchema(
                 name=f"item_{i}",
                 description="d",
                 test_model_serializer=(
@@ -454,10 +453,10 @@ class BulkFKCacheOptimizationTestCase(TestCase):
             for i in range(10)
         ]
 
-        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
-            success, errors = await self.model_util.bulk_create_s(
-                request, data_list
-            )
+        with _count_fk_resolutions(
+            models.TestModelSerializerReverseForeignKey
+        ) as resolved_pks:
+            success, errors = await self.model_util.bulk_create_s(request, data_list)
 
         self.assertEqual(errors, [])
         self.assertEqual(len(success), 10)
@@ -467,44 +466,28 @@ class BulkFKCacheOptimizationTestCase(TestCase):
     async def test_bulk_update_dedupes_repeated_fk_resolution(self):
         """bulk_update_s items sharing the same new FK value must resolve
         that FK once, not once per item."""
-        from ninja import Schema
-
         objs = [
             await models.TestModelSerializerForeignKey.objects.acreate(
-                name=f"existing_{i}",
-                description="d",
-                test_model_serializer=self.rev_fk_1,
+                name=f"existing_{i}", description="d", test_model_serializer=self.rev_fk_1
             )
             for i in range(5)
         ]
-
-        class UpdateSchema(Schema):
-            name: str | None = None
-            description: str | None = None
-            test_model_serializer: int | None = None
-
         request = mock.Mock()
-        resolved_pks = []
-        original_get_object = ModelUtil.get_object
-
-        async def counting_get_object(self, request, pk=None, **kwargs):
-            if self.model is models.TestModelSerializerReverseForeignKey:
-                resolved_pks.append(pk)
-            return await original_get_object(self, request, pk=pk, **kwargs)
-
         data_list = [
-            (obj.pk, UpdateSchema(test_model_serializer=self.rev_fk_2.id))
+            (obj.pk, _FKUpdateSchema(test_model_serializer=self.rev_fk_2.id))
             for obj in objs
         ]
 
-        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+        with _count_fk_resolutions(
+            models.TestModelSerializerReverseForeignKey
+        ) as resolved_pks:
             success, errors = await self.model_util.bulk_update_s(request, data_list)
 
         self.assertEqual(errors, [])
         self.assertEqual(len(success), 5)
         # One resolution for the shared new FK value (get_object calls from
         # fetching each target object itself are for a different model and
-        # are filtered out above).
+        # are filtered out by _count_fk_resolutions).
         self.assertEqual(resolved_pks, [self.rev_fk_2.id])
 
     @async_to_sync
@@ -512,35 +495,22 @@ class BulkFKCacheOptimizationTestCase(TestCase):
         """create_s (no batch) must not accidentally cache across independent
         calls: two sequential single creates for two different FK values must
         each resolve their own FK."""
-        from ninja import Schema
-
-        class CreateSchema(Schema):
-            name: str
-            description: str
-            test_model_serializer: int
-
         request = mock.Mock()
-        resolved_pks = []
-        original_get_object = ModelUtil.get_object
-
-        async def counting_get_object(self, request, pk=None, **kwargs):
-            if self.model is models.TestModelSerializerReverseForeignKey:
-                resolved_pks.append(pk)
-            return await original_get_object(self, request, pk=pk, **kwargs)
-
         read_schema = models.TestModelSerializerForeignKey.generate_read_s()
 
-        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+        with _count_fk_resolutions(
+            models.TestModelSerializerReverseForeignKey
+        ) as resolved_pks:
             await self.model_util.create_s(
                 request,
-                CreateSchema(
+                _FKCreateSchema(
                     name="a", description="d", test_model_serializer=self.rev_fk_1.id
                 ),
                 read_schema,
             )
             await self.model_util.create_s(
                 request,
-                CreateSchema(
+                _FKCreateSchema(
                     name="b", description="d", test_model_serializer=self.rev_fk_1.id
                 ),
                 read_schema,

--- a/tests/models/test_fk_optimization.py
+++ b/tests/models/test_fk_optimization.py
@@ -5,6 +5,8 @@ This module tests that the FK resolution optimization in create_s and update_s
 maintains correct functionality while reducing redundant database queries.
 """
 
+from unittest import mock
+
 from django.test import TestCase, tag
 from asgiref.sync import async_to_sync
 
@@ -356,3 +358,194 @@ class FKOptimizationTestCase(TestCase):
         self.assertEqual(result["test_model_serializer"]["id"], self.rev_fk_1.id)
         # Verify description updated
         self.assertEqual(result["description"], "Updated description")
+
+
+@tag("fk_optimization", "bulk_fk_cache")
+class BulkFKCacheOptimizationTestCase(TestCase):
+    """Regression tests for the per-batch FK resolution cache.
+
+    `bulk_create_s`/`bulk_update_s` share a request-scoped `fk_cache` across
+    the items of a single batch (`ninja_aio/models/utils.py::_resolve_fk`), so
+    a FK value repeated across items is resolved once instead of once per
+    item. Single `create_s`/`update_s` calls are unaffected (fk_cache=None).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.rev_fk_1 = models.TestModelSerializerReverseForeignKey.objects.create(
+            name="reverse_fk_1", description="First reverse FK"
+        )
+        cls.rev_fk_2 = models.TestModelSerializerReverseForeignKey.objects.create(
+            name="reverse_fk_2", description="Second reverse FK"
+        )
+
+    def setUp(self):
+        self.model_util = ModelUtil(models.TestModelSerializerForeignKey)
+
+    @async_to_sync
+    async def test_bulk_create_dedupes_repeated_fk_resolution(self):
+        """10 items sharing the same FK value must resolve that FK once, not
+        once per item."""
+        from django.http import HttpRequest
+        from ninja import Schema
+
+        class CreateSchema(Schema):
+            name: str
+            description: str
+            test_model_serializer: int
+
+        request = HttpRequest()
+        resolved_pks = []
+        original_get_object = ModelUtil.get_object
+
+        async def counting_get_object(self, request, pk=None, **kwargs):
+            if self.model is models.TestModelSerializerReverseForeignKey:
+                resolved_pks.append(pk)
+            return await original_get_object(self, request, pk=pk, **kwargs)
+
+        data_list = [
+            CreateSchema(
+                name=f"item_{i}",
+                description="d",
+                test_model_serializer=self.rev_fk_1.id,
+            )
+            for i in range(10)
+        ]
+
+        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+            success, errors = await self.model_util.bulk_create_s(
+                request, data_list
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(success), 10)
+        # Without the cache this would be 10 - one resolution per item.
+        self.assertEqual(resolved_pks, [self.rev_fk_1.id])
+
+    @async_to_sync
+    async def test_bulk_create_resolves_each_distinct_fk_once(self):
+        """Two distinct FK values across a batch must each resolve exactly
+        once, regardless of how many items reference them."""
+        from django.http import HttpRequest
+        from ninja import Schema
+
+        class CreateSchema(Schema):
+            name: str
+            description: str
+            test_model_serializer: int
+
+        request = HttpRequest()
+        resolved_pks = []
+        original_get_object = ModelUtil.get_object
+
+        async def counting_get_object(self, request, pk=None, **kwargs):
+            if self.model is models.TestModelSerializerReverseForeignKey:
+                resolved_pks.append(pk)
+            return await original_get_object(self, request, pk=pk, **kwargs)
+
+        data_list = [
+            CreateSchema(
+                name=f"item_{i}",
+                description="d",
+                test_model_serializer=(
+                    self.rev_fk_1.id if i % 2 == 0 else self.rev_fk_2.id
+                ),
+            )
+            for i in range(10)
+        ]
+
+        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+            success, errors = await self.model_util.bulk_create_s(
+                request, data_list
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(success), 10)
+        self.assertEqual(sorted(resolved_pks), sorted([self.rev_fk_1.id, self.rev_fk_2.id]))
+
+    @async_to_sync
+    async def test_bulk_update_dedupes_repeated_fk_resolution(self):
+        """bulk_update_s items sharing the same new FK value must resolve
+        that FK once, not once per item."""
+        from ninja import Schema
+
+        objs = [
+            await models.TestModelSerializerForeignKey.objects.acreate(
+                name=f"existing_{i}",
+                description="d",
+                test_model_serializer=self.rev_fk_1,
+            )
+            for i in range(5)
+        ]
+
+        class UpdateSchema(Schema):
+            name: str | None = None
+            description: str | None = None
+            test_model_serializer: int | None = None
+
+        request = mock.Mock()
+        resolved_pks = []
+        original_get_object = ModelUtil.get_object
+
+        async def counting_get_object(self, request, pk=None, **kwargs):
+            if self.model is models.TestModelSerializerReverseForeignKey:
+                resolved_pks.append(pk)
+            return await original_get_object(self, request, pk=pk, **kwargs)
+
+        data_list = [
+            (obj.pk, UpdateSchema(test_model_serializer=self.rev_fk_2.id))
+            for obj in objs
+        ]
+
+        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+            success, errors = await self.model_util.bulk_update_s(request, data_list)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(success), 5)
+        # One resolution for the shared new FK value (get_object calls from
+        # fetching each target object itself are for a different model and
+        # are filtered out above).
+        self.assertEqual(resolved_pks, [self.rev_fk_2.id])
+
+    @async_to_sync
+    async def test_single_create_does_not_share_cache_across_calls(self):
+        """create_s (no batch) must not accidentally cache across independent
+        calls: two sequential single creates for two different FK values must
+        each resolve their own FK."""
+        from ninja import Schema
+
+        class CreateSchema(Schema):
+            name: str
+            description: str
+            test_model_serializer: int
+
+        request = mock.Mock()
+        resolved_pks = []
+        original_get_object = ModelUtil.get_object
+
+        async def counting_get_object(self, request, pk=None, **kwargs):
+            if self.model is models.TestModelSerializerReverseForeignKey:
+                resolved_pks.append(pk)
+            return await original_get_object(self, request, pk=pk, **kwargs)
+
+        read_schema = models.TestModelSerializerForeignKey.generate_read_s()
+
+        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+            await self.model_util.create_s(
+                request,
+                CreateSchema(
+                    name="a", description="d", test_model_serializer=self.rev_fk_1.id
+                ),
+                read_schema,
+            )
+            await self.model_util.create_s(
+                request,
+                CreateSchema(
+                    name="b", description="d", test_model_serializer=self.rev_fk_1.id
+                ),
+                read_schema,
+            )
+
+        # Each independent create_s call resolves the FK on its own; there is
+        # no cross-request cache leaking state between unrelated calls.
+        self.assertEqual(resolved_pks, [self.rev_fk_1.id, self.rev_fk_1.id])

--- a/tests/models/test_model_util.py
+++ b/tests/models/test_model_util.py
@@ -236,6 +236,93 @@ class ModelUtilQObjectFiltersTestCase(TestCase):
             )
 
 
+@tag("model_util_delete_s_instance")
+class ModelUtilDeleteSInstanceTestCase(TestCase):
+    """delete_s(instance=...) must delete the given instance directly, without
+    an extra lookup query, while still running the normal delete hooks."""
+
+    async def test_delete_s_with_instance_skips_lookup(self):
+        obj = await models.TestModel.objects.acreate(name="x", description="d")
+        util = ModelUtil(models.TestModel)
+        request = mock.Mock()
+
+        with mock.patch.object(
+            util, "get_object", side_effect=AssertionError("should not be called")
+        ):
+            await util.delete_s(request, obj.pk, instance=obj)
+
+        self.assertFalse(
+            await models.TestModel.objects.filter(pk=obj.pk).aexists()
+        )
+
+    async def test_delete_s_without_instance_still_looks_up(self):
+        """Backward-compatible default: no instance -> falls back to get_object."""
+        obj = await models.TestModel.objects.acreate(name="y", description="d")
+        util = ModelUtil(models.TestModel)
+        request = mock.Mock()
+
+        await util.delete_s(request, obj.pk)
+
+        self.assertFalse(
+            await models.TestModel.objects.filter(pk=obj.pk).aexists()
+        )
+
+
+@tag("model_util_queryset_optimizations_preserved")
+class ModelUtilQuerysetOptimizationsPreservedTestCase(TestCase):
+    """Regression test for ninja_aio/models/utils.py `_get_base_queryset`.
+
+    `select_related`/`prefetch_related` declared under `QuerySet.read`/`QuerySet.detail`
+    must survive the default `queryset_request` hook. Previously, the read/detail-scoped
+    optimizations were applied and then unconditionally discarded by replacing the
+    queryset with whatever the (default, unrelated-scope) `queryset_request` hook
+    returned — causing an N+1 query per row for any relation field in the output schema.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.parent = models.TestModelSerializerReverseForeignKey.objects.create(
+            name="parent", description="parent_desc"
+        )
+        models.TestModelSerializerForeignKey.objects.bulk_create(
+            [
+                models.TestModelSerializerForeignKey(
+                    name=f"child_{i}",
+                    description="d",
+                    test_model_serializer=cls.parent,
+                )
+                for i in range(5)
+            ]
+        )
+
+    async def test_select_related_survives_default_queryset_request_hook(self):
+        """select_related declared in QuerySet.read must be applied to the queryset
+        returned by get_objects, even though the default queryset_request hook runs
+        (with_qs_request defaults to True for list/retrieve)."""
+        util = models.TestModelSerializerForeignKey.util
+        request = mock.Mock()
+
+        qs = await util.get_objects(request, is_for="read")
+
+        self.assertIn("test_model_serializer", qs.query.select_related)
+
+    async def test_relation_access_does_not_trigger_extra_queries(self):
+        """Rows from get_objects() must come back with the FK relation already
+        cached by the JOIN (select_related), so accessing it needs no extra query
+        (N+1) now that the optimization survives the queryset_request hook."""
+        util = models.TestModelSerializerForeignKey.util
+        request = mock.Mock()
+
+        qs = await util.get_objects(request, is_for="read")
+        objs = [obj async for obj in qs]
+
+        self.assertEqual(len(objs), 5)
+        for obj in objs:
+            # Populated by the JOIN only if select_related actually ran;
+            # otherwise Django would need a fresh query to resolve this.
+            self.assertIn("test_model_serializer", obj._state.fields_cache)
+
+
 # ============================================================
 # Coverage test for models/utils.py — line 791
 # ============================================================

--- a/tests/views/test_bulk.py
+++ b/tests/views/test_bulk.py
@@ -200,10 +200,10 @@ class BulkModelViewSetTestCase(TestCase):
 
         original = self.viewset.model_util._create_instance
 
-        async def mock_create(request, data):
+        async def mock_create(request, data, *args, **kwargs):
             if data.name == "bad_item":
                 raise SerializeError("create failed")
-            return await original(request, data)
+            return await original(request, data, *args, **kwargs)
 
         with patch.object(
             self.viewset.model_util, "_create_instance", side_effect=mock_create

--- a/tests/views/test_viewset.py
+++ b/tests/views/test_viewset.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 from django.db.models import Q
 from django.test import tag, TestCase
@@ -1531,4 +1532,30 @@ class PerOperationOutSchemaTestCase(TestCase):
         self.assertIn("name", content)
         self.assertEqual(content["name"], "to_delete_out")
         self.assertNotIn("description", content)
+        self.assertFalse(await self.model.objects.filter(pk=pk).aexists())
+
+    async def test_delete_with_schema_out_fetches_object_only_once(self):
+        """Regression test: delete_view with schema_delete_out must fetch the
+        object once (to serialize it), not once for serialization and again
+        inside delete_s to perform the delete."""
+        obj = await self.model.objects.acreate(name="fetch_once", description="d")
+        pk = obj.pk
+        view = self.delete_out_viewset.delete_view()
+        path_schema = self.delete_out_viewset.path_schema(**{self.pk_att: pk})
+
+        original_get_object = ModelUtil.get_object
+        call_count = 0
+
+        async def counting_get_object(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return await original_get_object(self, *args, **kwargs)
+
+        with mock.patch.object(ModelUtil, "get_object", counting_get_object):
+            result = await view(self.request.delete(), path_schema)
+
+        self.assertEqual(result.status_code, 200)
+        # Previously 2: one in delete_view to fetch+serialize, one inside
+        # delete_s to re-fetch the same object just to delete it.
+        self.assertEqual(call_count, 1)
         self.assertFalse(await self.model.objects.filter(pk=pk).aexists())


### PR DESCRIPTION
## Summary

Three targeted performance/correctness fixes found via profiling (`cProfile` + the project's own benchmark suite), same pattern each time: redundant or dropped database work in `ninja_aio`'s own query/serialization glue code, not something a bigger rewrite would fix.

- **N+1 on list/retrieve with relations** — `_get_base_queryset` applied read/detail-scoped `select_related`/`prefetch_related`, then unconditionally overwrote the queryset with the default `queryset_request` hook's result (a different, usually-empty scope), silently discarding the optimization. Fixed by applying the scoped optimizations *after* the hook runs.
- **Duplicate FK resolution in bulk create/update** — `_resolve_fk` re-fetched the same related object once per item even when many items in a batch shared the same FK value. Fixed with a request-scoped `fk_cache` shared across the items of one `bulk_create_s`/`bulk_update_s` call.
- **Duplicate fetch on delete with `schema_delete_out`** — the object was fetched once to serialize it, then fetched *again* inside `delete_s` just to delete it. `delete_s` now accepts an optional `instance=` to skip the second lookup.

All three are backward compatible — new parameters default to prior behavior — and verified as bugs before being touched (not assumed).

## Verification

- New regression tests for all three fixes (query-preservation, FK-cache dedup across batches vs. no cross-request leakage, delete fetch-count spy)
- `run-tests.sh`: 1065/1065 passing
- Full coverage suite: 1108/1108 passing, 100% coverage on both changed files (`models/utils.py`, `views/api.py`)
- `detect_regression.py`: 0 regressions; confirms the two predicted wins — `relation_filter` -63.09%, `bulk_create_50x3fk` -33.01%

## Also in this PR

- Version bump to `2.34.2`
- `CHANGELOG.md` entry
- `TODO.md` updated with the three completed tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)