### PR TITLE
chore: gitignore graphify-out/, dedupe colliding test model name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,4 @@ devdashboard/
 .devdashboard.json
 coverage.json
 .claude/
+graphify-out/

--- a/tests/models/test_models_extra.py
+++ b/tests/models/test_models_extra.py
@@ -607,7 +607,7 @@ class ModelUtilHelperMethodsTestCase(TestCase):
     async def test_process_payload_fields_with_binary(self):
         """_process_payload_fields should decode binary fields."""
 
-        class BinSerializer(ModelSerializer):
+        class ProcessPayloadBinSerializer(ModelSerializer):
             data = models.BinaryField()
 
             class CreateSerializer:
@@ -616,7 +616,7 @@ class ModelUtilHelperMethodsTestCase(TestCase):
             class Meta:
                 app_label = app_models.TestModelSerializer._meta.app_label
 
-        util = ModelUtil(BinSerializer)
+        util = ModelUtil(ProcessPayloadBinSerializer)
         good_bytes = b"hello"
         b64 = base64.b64encode(good_bytes).decode()
         payload = {"data": b64}


### PR DESCRIPTION
## Summary

Two small cleanups noticed while reviewing test output:

- `graphify-out/` (the knowledge-graph pipeline's output directory) was untracked but not actually gitignored — added it to `.gitignore`.
- `tests/models/test_models_extra.py` declared two separate local `ModelSerializer` classes both named `BinSerializer` with the same `app_label`, colliding in Django's app registry and printing a `RuntimeWarning: Model 'test_app.binserializer' was already registered` on every single test run. Renamed the second one to `ProcessPayloadBinSerializer` — no behavior change, just removes log noise that could mask a real duplicate-registration warning later.

(The other two warnings seen in test output — `Tool 'does_not_exist' not listed` and `Failed to decode binary field... Incorrect padding` — are from intentional negative-path tests and are expected; left as-is.)

## Verification

`run-tests.sh`: 1065/1065 passing, and the `RuntimeWarning` no longer appears in output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)